### PR TITLE
Add Windows install script (install.cmd)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 host/native-host-wrapper.sh
+host/native-host-wrapper.cmd
 .env
 *.log
 .DS_Store

--- a/install.cmd
+++ b/install.cmd
@@ -13,12 +13,12 @@ if "%~1"=="" (
     echo Each browser assigns a different ID to the same unpacked extension.
     echo.
     echo Steps:
-    echo   1. Open chrome://extensions ^(and/or edge://extensions^)
+    echo   1. Open chrome://extensions, edge://extensions, and/or brave://extensions
     echo   2. Enable Developer Mode
     echo   3. Click 'Load unpacked' and select the extension\ directory
     echo   4. Copy the extension ID shown under the extension name
     echo   5. Repeat for each browser
-    echo   6. Run: install.cmd ^<chrome-id^> ^<edge-id^>
+    echo   6. Run: install.cmd ^<chrome-id^> ^<edge-id^> ^<brave-id^>
     exit /b 1
 )
 
@@ -42,6 +42,11 @@ if not exist "%HOST_DIR%\node_modules" (
     echo Installing npm dependencies...
     pushd "%HOST_DIR%"
     call npm install
+    if errorlevel 1 (
+        echo Error: npm install failed.
+        popd
+        exit /b 1
+    )
     popd
 )
 

--- a/install.cmd
+++ b/install.cmd
@@ -94,16 +94,31 @@ echo.
 echo Installing native messaging host for browsers...
 
 REM Register for Chrome
-reg add "HKCU\Software\Google\Chrome\NativeMessagingHosts\%HOST_NAME%" /ve /d "%MANIFEST_PATH%" /f >nul 2>nul
-echo   Registered for Google Chrome
+if exist "%ProgramFiles%\Google\Chrome\Application\chrome.exe" (
+    reg add "HKCU\Software\Google\Chrome\NativeMessagingHosts\%HOST_NAME%" /ve /d "%MANIFEST_PATH%" /f >nul 2>nul
+    echo   Registered for Google Chrome
+) else (
+    echo   Skipping Google Chrome ^(not installed^)
+)
 
 REM Register for Edge
-reg add "HKCU\Software\Microsoft\Edge\NativeMessagingHosts\%HOST_NAME%" /ve /d "%MANIFEST_PATH%" /f >nul 2>nul
-echo   Registered for Microsoft Edge
+if exist "%ProgramFiles(x86)%\Microsoft\Edge\Application\msedge.exe" (
+    reg add "HKCU\Software\Microsoft\Edge\NativeMessagingHosts\%HOST_NAME%" /ve /d "%MANIFEST_PATH%" /f >nul 2>nul
+    echo   Registered for Microsoft Edge
+) else if exist "%ProgramFiles%\Microsoft\Edge\Application\msedge.exe" (
+    reg add "HKCU\Software\Microsoft\Edge\NativeMessagingHosts\%HOST_NAME%" /ve /d "%MANIFEST_PATH%" /f >nul 2>nul
+    echo   Registered for Microsoft Edge
+) else (
+    echo   Skipping Microsoft Edge ^(not installed^)
+)
 
 REM Register for Brave
-reg add "HKCU\Software\BraveSoftware\Brave-Browser\NativeMessagingHosts\%HOST_NAME%" /ve /d "%MANIFEST_PATH%" /f >nul 2>nul
-echo   Registered for Brave Browser
+if exist "%ProgramFiles%\BraveSoftware\Brave-Browser\Application\brave.exe" (
+    reg add "HKCU\Software\BraveSoftware\Brave-Browser\NativeMessagingHosts\%HOST_NAME%" /ve /d "%MANIFEST_PATH%" /f >nul 2>nul
+    echo   Registered for Brave Browser
+) else (
+    echo   Skipping Brave Browser ^(not installed^)
+)
 
 echo.
 echo Done! Next steps:

--- a/install.cmd
+++ b/install.cmd
@@ -1,0 +1,114 @@
+@echo off
+setlocal enabledelayedexpansion
+
+REM Install script for Open Claude in Chrome extension (Windows).
+REM Registers the native messaging host for Chrome, Edge, and Brave.
+REM
+REM Usage: install.cmd <extension-id> [extension-id-2] [extension-id-3] ...
+
+if "%~1"=="" (
+    echo Usage: install.cmd ^<extension-id^> [extension-id-2] ...
+    echo.
+    echo Pass one extension ID per browser you want to use.
+    echo Each browser assigns a different ID to the same unpacked extension.
+    echo.
+    echo Steps:
+    echo   1. Open chrome://extensions ^(and/or edge://extensions^)
+    echo   2. Enable Developer Mode
+    echo   3. Click 'Load unpacked' and select the extension\ directory
+    echo   4. Copy the extension ID shown under the extension name
+    echo   5. Repeat for each browser
+    echo   6. Run: install.cmd ^<chrome-id^> ^<edge-id^>
+    exit /b 1
+)
+
+set "SCRIPT_DIR=%~dp0"
+set "HOST_DIR=%SCRIPT_DIR%host"
+set "WRAPPER_PATH=%HOST_DIR%\native-host-wrapper.cmd"
+set "HOST_NAME=com.anthropic.open_claude_in_chrome"
+set "MANIFEST_DIR=%LOCALAPPDATA%\Google\Chrome\NativeMessagingHosts"
+set "MANIFEST_PATH=%MANIFEST_DIR%\%HOST_NAME%.json"
+
+REM Verify node is available
+where node >nul 2>nul
+if errorlevel 1 (
+    echo Error: node is not installed. Install Node.js first.
+    exit /b 1
+)
+for /f "delims=" %%i in ('where node') do set "NODE_PATH=%%i"
+
+REM Install npm dependencies
+if not exist "%HOST_DIR%\node_modules" (
+    echo Installing npm dependencies...
+    pushd "%HOST_DIR%"
+    call npm install
+    popd
+)
+
+REM Create the native host wrapper
+(
+    echo @echo off
+    echo "%NODE_PATH%" "%%~dp0native-host.js"
+)> "%WRAPPER_PATH%"
+
+echo Created native host wrapper: %WRAPPER_PATH%
+
+REM Collect extension IDs
+set "COUNT=0"
+:parse_args
+if "%~1"=="" goto done_args
+set "EXT_ID[!COUNT!]=%~1"
+set /a COUNT+=1
+shift
+goto parse_args
+:done_args
+
+REM Generate manifest JSON
+if not exist "%MANIFEST_DIR%" mkdir "%MANIFEST_DIR%"
+set "JSON_PATH=%WRAPPER_PATH:\=\\%"
+
+> "%MANIFEST_PATH%" echo {
+>> "%MANIFEST_PATH%" echo   "name": "%HOST_NAME%",
+>> "%MANIFEST_PATH%" echo   "description": "Open Claude in Chrome Native Messaging Host",
+>> "%MANIFEST_PATH%" echo   "path": "%JSON_PATH%",
+>> "%MANIFEST_PATH%" echo   "type": "stdio",
+>> "%MANIFEST_PATH%" echo   "allowed_origins": [
+set /a LAST=COUNT-1
+for /l %%i in (0,1,!LAST!) do (
+    if %%i lss !LAST! (
+        >> "%MANIFEST_PATH%" echo     "chrome-extension://!EXT_ID[%%i]!/",
+    ) else (
+        >> "%MANIFEST_PATH%" echo     "chrome-extension://!EXT_ID[%%i]!/"
+    )
+)
+>> "%MANIFEST_PATH%" echo   ]
+>> "%MANIFEST_PATH%" echo }
+
+echo Created manifest: %MANIFEST_PATH%
+echo.
+echo Installing native messaging host for browsers...
+
+REM Register for Chrome
+reg add "HKCU\Software\Google\Chrome\NativeMessagingHosts\%HOST_NAME%" /ve /d "%MANIFEST_PATH%" /f >nul 2>nul
+echo   Registered for Google Chrome
+
+REM Register for Edge
+reg add "HKCU\Software\Microsoft\Edge\NativeMessagingHosts\%HOST_NAME%" /ve /d "%MANIFEST_PATH%" /f >nul 2>nul
+echo   Registered for Microsoft Edge
+
+REM Register for Brave
+reg add "HKCU\Software\BraveSoftware\Brave-Browser\NativeMessagingHosts\%HOST_NAME%" /ve /d "%MANIFEST_PATH%" /f >nul 2>nul
+echo   Registered for Brave Browser
+
+echo.
+echo Done! Next steps:
+echo.
+echo   1. Restart your browser (close all windows and reopen)
+echo   2. Add the MCP server to Claude Code:
+echo.
+echo      claude mcp add open-claude-in-chrome -- node "%HOST_DIR%\mcp-server.js"
+echo.
+echo   3. Start a new Claude Code session and test:
+echo.
+echo      Ask Claude: "Navigate to reddit.com and take a screenshot"
+echo.


### PR DESCRIPTION
## Summary

- Add `install.cmd` as the Windows equivalent of `install.sh`
- Generates `native-host-wrapper.cmd` and manifest JSON in `%LOCALAPPDATA%\Google\Chrome\NativeMessagingHosts\`
- Registers native messaging host via registry for Chrome, Edge, and Brave
- Add `host/native-host-wrapper.cmd` to `.gitignore` (generated artifact, symmetric to `.sh`)

## Motivation

`install.sh` currently exits with an error on Windows ("Unsupported platform"). This adds first-class Windows support using the same workflow: run the script with extension ID(s), and everything is configured automatically.

## Test plan

- [x] Run `install.cmd <extension-id>` on Windows
- [x] Verify `host\native-host-wrapper.cmd` is generated with correct node path
- [x] Verify manifest JSON is created in `%LOCALAPPDATA%\Google\Chrome\NativeMessagingHosts\`
- [x] Verify registry entries exist under `HKCU\Software\Google\Chrome\NativeMessagingHosts\`
- [x] Restart browser and confirm native messaging connection works