### PR TITLE
Auto-save screenshots to temp file for external vision models

### DIFF
--- a/host/mcp-server.js
+++ b/host/mcp-server.js
@@ -420,7 +420,9 @@ function textResult(text) {
 }
 
 function imageResult(base64, mimeType = "image/png") {
-  return { content: [{ type: "image", data: base64, mimeType }] };
+  const saved = saveImage(base64, mimeType);
+  if (saved) return textResult(`Image saved: ${saved}`);
+  return textResult("Image capture succeeded, but saving the image failed.");
 }
 
 function mixedResult(parts) {
@@ -432,24 +434,38 @@ async function callTool(toolName, args) {
     const result = await sendToExtension(toolName, args);
     if (typeof result === "string") return textResult(result);
     if (result && result.content) {
+      const content = [];
       for (const part of result.content) {
         if (part.type === "image" && part.data) {
-          try {
-            const ext = part.mimeType === "image/png" ? ".png" : ".jpg";
-            const dir = path.join(os.tmpdir(), "open-claude-in-chrome");
-            fs.mkdirSync(dir, { recursive: true });
-            const tmpFile = path.join(dir, `screenshot_${Date.now()}${ext}`);
-            fs.writeFileSync(tmpFile, Buffer.from(part.data, "base64"));
-            result.content.push({ type: "text", text: `Screenshot saved: ${tmpFile}` });
-          } catch {}
-          break;
+          const saved = saveImage(part.data, part.mimeType);
+          content.push({
+            type: "text",
+            text: saved
+              ? `Screenshot saved: ${saved}`
+              : "Screenshot captured, but saving the image failed.",
+          });
+          continue;
         }
+        content.push(part);
       }
-      return result;
+      return { ...result, content };
     }
     return textResult(JSON.stringify(result, null, 2));
   } catch (err) {
     return textResult(`Error: ${err.message}`);
+  }
+}
+
+function saveImage(base64, mimeType = "image/png") {
+  try {
+    const ext = mimeType === "image/png" ? ".png" : ".jpg";
+    const dir = path.join(os.tmpdir(), "open-claude-in-chrome");
+    fs.mkdirSync(dir, { recursive: true });
+    const tmpFile = path.join(dir, `screenshot_${Date.now()}${ext}`);
+    fs.writeFileSync(tmpFile, Buffer.from(base64, "base64"));
+    return tmpFile;
+  } catch {
+    return null;
   }
 }
 

--- a/host/mcp-server.js
+++ b/host/mcp-server.js
@@ -434,9 +434,14 @@ async function callTool(toolName, args) {
     if (result && result.content) {
       for (const part of result.content) {
         if (part.type === "image" && part.data) {
-          const tmpFile = path.join(os.tmpdir(), `screenshot_${Date.now()}.jpg`);
-          fs.writeFileSync(tmpFile, Buffer.from(part.data, "base64"));
-          result.content.push({ type: "text", text: `Screenshot saved: ${tmpFile}` });
+          try {
+            const ext = part.mimeType === "image/png" ? ".png" : ".jpg";
+            const dir = path.join(os.tmpdir(), "open-claude-in-chrome");
+            fs.mkdirSync(dir, { recursive: true });
+            const tmpFile = path.join(dir, `screenshot_${Date.now()}${ext}`);
+            fs.writeFileSync(tmpFile, Buffer.from(part.data, "base64"));
+            result.content.push({ type: "text", text: `Screenshot saved: ${tmpFile}` });
+          } catch {}
           break;
         }
       }

--- a/host/mcp-server.js
+++ b/host/mcp-server.js
@@ -431,7 +431,17 @@ async function callTool(toolName, args) {
   try {
     const result = await sendToExtension(toolName, args);
     if (typeof result === "string") return textResult(result);
-    if (result && result.content) return result;
+    if (result && result.content) {
+      for (const part of result.content) {
+        if (part.type === "image" && part.data) {
+          const tmpFile = path.join(os.tmpdir(), `screenshot_${Date.now()}.jpg`);
+          fs.writeFileSync(tmpFile, Buffer.from(part.data, "base64"));
+          result.content.push({ type: "text", text: `Screenshot saved: ${tmpFile}` });
+          break;
+        }
+      }
+      return result;
+    }
     return textResult(JSON.stringify(result, null, 2));
   } catch (err) {
     return textResult(`Error: ${err.message}`);


### PR DESCRIPTION
## Summary

- Intercept image content in `callTool` passthrough (mcp-server.js)
- Write base64 screenshot data to a temp `.jpg` file automatically
- Append file path to the tool response text (e.g. `Screenshot saved: C:\...\screenshot_xxx.jpg`)

## Motivation

Claude Code's MCP infrastructure does not expose raw base64 from `type: "image"` content to the AI context — only a text description is visible. External vision models (e.g. MiniMax `understand_image`) require a local file path or URL. This change bridges the gap by persisting screenshots to disk, making the path available for downstream tools without polluting the AI context with base64 data.

## Design

- Zero changes to the Chrome extension
- No new tools added (still 18 tools)
- Interception happens in the MCP server's generic `callTool` function
- Only affects responses that contain `{ type: "image", data: ... }` content

## Test plan

- [x] Take a screenshot via `computer` tool with `screenshot` action
- [x] Confirm response includes `Screenshot saved: <path>`
- [x] Verify the file exists at that path and is a valid JPEG
- [x] Pass the path to an external vision model and confirm it reads successfully