### PR TITLE
feat: auto-select default browser on startup via config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 host/native-host-wrapper.sh
+host/com.anthropic.open_claude_in_chrome.json
 .env
 *.log
 .DS_Store

--- a/host/mcp-server.js
+++ b/host/mcp-server.js
@@ -20,17 +20,23 @@ import { z } from "zod";
 
 const DEFAULT_PORT = 18765;
 
-function getPort() {
+function readConfig() {
   const configPath = path.join(os.homedir(), ".config", "open-claude-in-chrome", "config.json");
   try {
-    const config = JSON.parse(fs.readFileSync(configPath, "utf-8"));
-    return config.port || DEFAULT_PORT;
+    return JSON.parse(fs.readFileSync(configPath, "utf-8"));
   } catch {
-    return DEFAULT_PORT;
+    return {};
   }
 }
 
+function getPort() {
+  const config = readConfig();
+  return config.port || DEFAULT_PORT;
+}
+
 const TCP_PORT = getPort();
+const DEFAULT_DEVICE_ID = readConfig().deviceId || null;
+let autoSelectSent = false;
 
 // --- Mode detection ---
 // Try to bind the port. If it's taken, switch to client mode.
@@ -248,6 +254,15 @@ function setupNativeHostConnection(socket, initialBuffer) {
       }, 5000);
     }
   });
+
+  // Auto-select browser if a default deviceId is configured
+  if (!autoSelectSent && DEFAULT_DEVICE_ID) {
+    autoSelectSent = true;
+    process.stderr.write(`Auto-selecting browser: ${DEFAULT_DEVICE_ID}\n`);
+    sendToExtension("select_browser", { deviceId: DEFAULT_DEVICE_ID })
+      .then(() => process.stderr.write("Browser auto-selected successfully.\n"))
+      .catch((err) => process.stderr.write(`Auto-select browser failed: ${err.message}\n`));
+  }
 }
 
 function setupClientConnection(socket, initialBuffer) {

--- a/host/native-host.bat
+++ b/host/native-host.bat
@@ -1,0 +1,2 @@
+@echo off
+node "%~dp0native-host.js"

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,89 @@
+# Install script for Open Claude in Chrome extension on Windows.
+# Registers the native messaging host for Chrome, Edge, and Brave.
+#
+# Usage: .\install.ps1 <extension-id> [extension-id-2] [extension-id-3] ...
+#
+# Pass one extension ID per browser. Each Chromium browser assigns a different
+# ID when loading unpacked extensions.
+
+param(
+    [Parameter(Mandatory=$true)]
+    [string[]]$ExtensionIds
+)
+
+$ErrorActionPreference = "Stop"
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$HostDir = Join-Path $ScriptDir "host"
+$HostName = "com.anthropic.open_claude_in_chrome"
+$NativeHostBat = Join-Path $HostDir "native-host.bat"
+$ManifestPath = Join-Path $HostDir "$HostName.json"
+
+# Verify node is available
+if (-not (Get-Command node -ErrorAction SilentlyContinue)) {
+    Write-Error "node is not installed. Install Node.js first."
+    exit 1
+}
+
+# Verify npm dependencies
+if (-not (Test-Path (Join-Path $HostDir "node_modules"))) {
+    Write-Host "Installing npm dependencies..."
+    Push-Location $HostDir
+    npm install
+    Pop-Location
+}
+
+# Verify native-host.bat exists
+if (-not (Test-Path $NativeHostBat)) {
+    Write-Error "native-host.bat not found at $NativeHostBat"
+    exit 1
+}
+
+# Build allowed_origins array
+$Origins = ($ExtensionIds | ForEach-Object { "chrome-extension://$_/" }) -join ",`n    "
+
+# Generate manifest
+$Manifest = @"
+{
+  "name": "$HostName",
+  "description": "Open Claude in Chrome Native Messaging Host",
+  "path": "$($NativeHostBat -replace '\\', '\\')",
+  "type": "stdio",
+  "allowed_origins": [
+    $Origins
+  ]
+}
+"@
+
+# Write manifest
+$Manifest | Out-File -FilePath $ManifestPath -Encoding utf8 -NoNewline
+Write-Host "Created manifest: $ManifestPath"
+
+# Register for each installed browser
+$Browsers = @(
+    @{Name="Google Chrome"; Path="HKCU:\Software\Google\Chrome\NativeMessagingHosts"},
+    @{Name="Microsoft Edge"; Path="HKCU:\Software\Microsoft Edge\NativeMessagingHosts"},
+    @{Name="Brave Browser"; Path="HKCU:\Software\BraveSoftware\Brave-Browser\NativeMessagingHosts"}
+)
+
+foreach ($browser in $Browsers) {
+    $keyPath = Join-Path $browser.Path $HostName
+    try {
+        New-Item -Path $keyPath -Force | Out-Null
+        New-ItemProperty -Path $keyPath -Name "(default)" -Value $ManifestPath -PropertyType String -Force | Out-Null
+        Write-Host "  Registered for $($browser.Name)"
+    } catch {
+        Write-Host "  Skipping $($browser.Name) (not installed or access denied)"
+    }
+}
+
+Write-Host ""
+Write-Host "Done! Next steps:"
+Write-Host ""
+Write-Host "  1. Restart your browser (close all windows and reopen)"
+Write-Host "  2. Add the MCP server to Claude Code:"
+Write-Host ""
+Write-Host "     claude mcp add open-claude-in-chrome -- node $HostDir\mcp-server.js"
+Write-Host ""
+Write-Host "  3. Start a new Claude Code session and test:"
+Write-Host ""
+Write-Host '     Ask Claude: "Navigate to reddit.com and take a screenshot"'


### PR DESCRIPTION
## Summary

Read `deviceId` from `~/.config/open-claude-in-chrome/config.json` and automatically call `select_browser` when the native host connects. This eliminates the need to manually select the browser in each session.

## Changes

- Extract `readConfig()` from `getPort()` to support reading additional config keys
- Read `deviceId` from config, defaulting to `null` (disabled)
- After native host connects, if a `deviceId` is configured, auto-send `select_browser` tool request
- `autoSelectSent` flag ensures auto-select only fires once per server lifetime
- Failures are logged but don't crash the server

## Configuration

Add `deviceId` to `~/.config/open-claude-in-chrome/config.json`:

```json
{
  "port": 18765,
  "deviceId": "gbplncbbfgiiapojgciedpgcoheiemgo"
}
```

## Test plan

- [ ] Start with no `deviceId` in config — server starts normally, no auto-select
- [ ] Add `deviceId` to config, restart MCP server — browser auto-selected on native host connect
- [ ] Verify `list_connected_browsers` shows the selected browser as active
- [ ] Test browser actions (navigate, screenshot) work after auto-select