### PR TITLE
Add Windows support for native messaging host installation

### DIFF
--- a/host/native-host.bat
+++ b/host/native-host.bat
@@ -1,0 +1,3 @@
+@echo off
+echo YES > "C:\Users\LENOVO\open-claude-in-chrome\host\started.txt"
+exit /b 0

--- a/host/native-host.mjs
+++ b/host/native-host.mjs
@@ -1,0 +1,145 @@
+#!/usr/bin/env node
+
+// Native Messaging Host for Open Claude in Chrome extension.
+// Launched by Chrome when the extension calls connectNative().
+// Bridges between Chrome native messaging (stdin/stdout, 4-byte LE length prefix + JSON)
+// and the MCP server (TCP on localhost).
+
+import net from "node:net";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+
+const DEFAULT_PORT = 18765;
+
+function getPort() {
+  const configPath = path.join(
+    os.homedir(),
+    ".config",
+    "open-claude-in-chrome",
+    "config.json"
+  );
+  try {
+    const config = JSON.parse(fs.readFileSync(configPath, "utf-8"));
+    return config.port || DEFAULT_PORT;
+  } catch {
+    return DEFAULT_PORT;
+  }
+}
+
+// --- Native messaging protocol (Chrome <-> this process) ---
+
+function readNativeMessage(buffer) {
+  const messages = [];
+  let offset = 0;
+  while (offset + 4 <= buffer.length) {
+    const len = buffer.readUInt32LE(offset);
+    if (offset + 4 + len > buffer.length) break;
+    const json = buffer.subarray(offset + 4, offset + 4 + len).toString("utf-8");
+    try {
+      messages.push(JSON.parse(json));
+    } catch (e) {
+      // skip malformed
+    }
+    offset += 4 + len;
+  }
+  return { messages, remainder: buffer.subarray(offset) };
+}
+
+function writeNativeMessage(obj) {
+  const json = JSON.stringify(obj);
+  const buf = Buffer.from(json, "utf-8");
+  const header = Buffer.alloc(4);
+  header.writeUInt32LE(buf.length, 0);
+  process.stdout.write(Buffer.concat([header, buf]));
+}
+
+// --- TCP connection to MCP server ---
+
+let tcpSocket = null;
+let tcpBuffer = Buffer.alloc(0);
+let reconnectTimer = null;
+let reconnectAttempts = 0;
+const MAX_RECONNECT_ATTEMPTS = 60; // 30 seconds at 500ms intervals
+const TCP_PORT = getPort();
+
+function connectTcp() {
+  if (tcpSocket) return;
+
+  tcpSocket = new net.Socket();
+
+  tcpSocket.connect(TCP_PORT, "127.0.0.1", () => {
+    reconnectAttempts = 0;
+    if (reconnectTimer) {
+      clearInterval(reconnectTimer);
+      reconnectTimer = null;
+    }
+  });
+
+  tcpSocket.on("data", (chunk) => {
+    // newline-delimited JSON from MCP server
+    tcpBuffer = Buffer.concat([tcpBuffer, chunk]);
+    let newlineIdx;
+    while ((newlineIdx = tcpBuffer.indexOf(10)) !== -1) {
+      const line = tcpBuffer.subarray(0, newlineIdx).toString("utf-8").trim();
+      tcpBuffer = tcpBuffer.subarray(newlineIdx + 1);
+      if (!line) continue;
+      try {
+        const msg = JSON.parse(line);
+        // Forward to extension via native messaging
+        writeNativeMessage(msg);
+      } catch {
+        // skip malformed
+      }
+    }
+  });
+
+  tcpSocket.on("error", (err) => {
+    process.stderr.write("TCP error: " + err.message + "\n");
+    tcpSocket = null;
+  });
+
+  tcpSocket.on("close", () => {
+    process.stderr.write("TCP close. Attempt=" + reconnectAttempts + "\n");
+    tcpSocket = null;
+    if (!reconnectTimer) {
+      reconnectTimer = setInterval(() => {
+        reconnectAttempts++;
+        process.stderr.write("Reconnect attempt " + reconnectAttempts + "\n");
+        if (reconnectAttempts > MAX_RECONNECT_ATTEMPTS) {
+          // MCP server is gone — exit cleanly so we don't linger as a zombie
+          clearInterval(reconnectTimer);
+          process.exit(0);
+        }
+        if (!tcpSocket) connectTcp();
+      }, 500);
+    }
+  });
+}
+
+// --- Main: bridge stdin (from extension) <-> TCP (to MCP server) ---
+
+let stdinBuffer = Buffer.alloc(0);
+
+process.stdin.on("data", (chunk) => {
+  stdinBuffer = Buffer.concat([stdinBuffer, chunk]);
+  const { messages, remainder } = readNativeMessage(stdinBuffer);
+  stdinBuffer = remainder;
+
+  for (const msg of messages) {
+    // Forward to MCP server via TCP
+    if (tcpSocket && !tcpSocket.destroyed) {
+      tcpSocket.write(JSON.stringify(msg) + "\n");
+    }
+  }
+});
+
+process.stdin.on("end", () => {
+  // Extension disconnected
+  if (tcpSocket) tcpSocket.destroy();
+  process.exit(0);
+});
+
+// Start TCP connection
+process.stderr.write("native-host started\n");
+connectTcp();

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,53 @@
+# Open Claude in Chrome - Windows Install Script
+# Run this AFTER loading the extension in Chrome
+# Usage: powershell -ExecutionPolicy Bypass -File install.ps1 <extension-id>
+
+param(
+    [Parameter(Mandatory=$true)]
+    [string]$ExtensionId
+)
+
+$HostName = "com.anthropic.open_claude_in_chrome"
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$HostDir = Join-Path $ScriptDir "host"
+$ManifestPath = Join-Path $HostDir "native-messaging-host.json"
+
+# Generate the native-host.bat launcher
+$BatPath = Join-Path $HostDir "native-host.bat"
+$NodePath = (Get-Command node -ErrorAction Stop).Source
+@"
+@echo off
+"$NodePath" "$HostDir\native-host.mjs"
+"@ | Out-File -FilePath $BatPath -Encoding ASCII
+Write-Host "[OK] Created native-host.bat"
+
+# Generate the native messaging host manifest
+$manifest = @{
+    name = $HostName
+    description = "Open Claude in Chrome Native Messaging Host"
+    path = $BatPath
+    type = "stdio"
+    allowed_origins = @("chrome-extension://$ExtensionId/")
+}
+$manifestJson = $manifest | ConvertTo-Json -Depth 3
+[System.IO.File]::WriteAllText($ManifestPath, $manifestJson, (New-Object System.Text.UTF8Encoding $false))
+Write-Host "[OK] Created manifest: $ManifestPath"
+
+# Register native messaging host in registry (correct subkey format)
+$browsers = @{
+    "Google Chrome" = "HKCU:\Software\Google\Chrome\NativeMessagingHosts\$HostName"
+    "Microsoft Edge" = "HKCU:\Software\Microsoft\Edge\NativeMessagingHosts\$HostName"
+    "Brave Browser" = "HKCU:\Software\BraveSoftware\Brave-Browser\NativeMessagingHosts\$HostName"
+}
+
+foreach ($browser in $browsers.GetEnumerator()) {
+    New-Item -Path $browser.Value -Force | Out-Null
+    Set-ItemProperty -Path $browser.Value -Name "(Default)" -Value $ManifestPath
+    Write-Host "[OK] Registered for $($browser.Key)"
+}
+
+Write-Host ""
+Write-Host "Done! Next steps:"
+Write-Host "  1. RESTART Chrome (close ALL windows, then reopen)"
+Write-Host "  2. Run: claude mcp add open-claude-in-chrome -- node $HostDir\mcp-server.js"
+Write-Host "  3. Start a new Claude Code session and test!"


### PR DESCRIPTION
The existing install.sh only supports macOS and Linux. This adds:
- install.ps1: PowerShell script that registers the native messaging host for Chrome, Edge, and Brave on Windows, using the correct registry format (subkeys with Default values, not named values)
- host/native-host.bat: Batch file launcher that Chrome invokes to bridge native messaging to the Node.js process
- host/native-host.mjs: ESM entry point for the native messaging host, unconditionally treated as ES module regardless of CWD (uses .mjs extension to avoid dependency on package.json type module)

Key Windows-specific fixes discovered during debugging:
- Registry entries must be subkeys with (Default) value, not named values
- Batch file must use absolute paths (Chrome CWD is unpredictable)
- Manifest JSON must be UTF-8 without BOM
- .mjs extension ensures Node.js treats the file as ESM without relying on the host/ directory package.json being discoverable at runtime