### PR TITLE
Add Windows installer for the native messaging host

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 node_modules/
 host/native-host-wrapper.sh
+host/native-host-wrapper.bat
+host/com.anthropic.open_claude_in_chrome.json
 .env
 *.log
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -99,14 +99,32 @@ cd ..
 
 ### Step 3: Register native messaging
 
+**macOS / Linux:**
+
 ```bash
 ./install.sh <your-extension-id>
 ```
 
-If you use multiple browsers, pass all IDs:
+**Windows (PowerShell):**
+
+```powershell
+.\install-windows.ps1 <your-extension-id>
+```
+
+The Windows script registers the host under `HKCU` (per-user, no admin required) for
+Chrome, Edge, Brave, and Chromium. If PowerShell blocks the script, allow it for the
+current session only:
+
+```powershell
+Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass
+```
+
+If you use multiple browsers, pass all IDs (each browser assigns a different ID to the
+same unpacked extension):
 
 ```bash
-./install.sh <chrome-id> <brave-id> <arc-id>
+./install.sh <chrome-id> <brave-id> <arc-id>       # macOS / Linux
+.\install-windows.ps1 <chrome-id> <edge-id>        # Windows
 ```
 
 ### Step 4: Restart your browser
@@ -122,7 +140,13 @@ claude mcp add open-claude-in-chrome -- node /absolute/path/to/host/mcp-server.j
 Find the absolute path with:
 
 ```bash
-echo "node $(pwd)/host/mcp-server.js"
+echo "node $(pwd)/host/mcp-server.js"        # macOS / Linux
+```
+
+On Windows, `install-windows.ps1` prints the exact command to run when it finishes, e.g.:
+
+```powershell
+claude mcp add open-claude-in-chrome -- node C:\path\to\host\mcp-server.js
 ```
 
 ## Verification
@@ -212,6 +236,13 @@ pkill -f "node.*mcp-server"
    - **Chrome (macOS)**: `~/Library/Application Support/Google/Chrome/NativeMessagingHosts/com.anthropic.open_claude_in_chrome.json`
    - **Brave (macOS)**: `~/Library/Application Support/BraveSoftware/Brave-Browser/NativeMessagingHosts/com.anthropic.open_claude_in_chrome.json`
    - **Edge (macOS)**: `~/Library/Application Support/Microsoft Edge/NativeMessagingHosts/com.anthropic.open_claude_in_chrome.json`
+   - **Windows**: the manifest lives at `host\com.anthropic.open_claude_in_chrome.json` and is
+     referenced by a registry value. Verify it with:
+     ```powershell
+     Get-ItemProperty 'HKCU:\Software\Google\Chrome\NativeMessagingHosts\com.anthropic.open_claude_in_chrome'
+     ```
+     (swap `Google\Chrome` for `Microsoft\Edge` or `BraveSoftware\Brave-Browser` as needed). Re-run
+     `.\install-windows.ps1 <extension-id>` if it is missing.
 
 ### MCP server not found
 
@@ -225,7 +256,7 @@ claude mcp add open-claude-in-chrome -- node /absolute/path/to/host/mcp-server.j
 The MCP server started but the native host hasn't connected. Try:
 1. Open any webpage (wakes the service worker)
 2. Check service worker logs: `chrome://extensions` > "Inspect views: service worker"
-3. Verify `host/native-host-wrapper.sh` exists
+3. Verify the host wrapper exists — `host/native-host-wrapper.sh` (macOS/Linux) or `host\native-host-wrapper.bat` (Windows)
 
 ### Tools fail immediately after reconnect
 

--- a/install-windows.ps1
+++ b/install-windows.ps1
@@ -1,0 +1,68 @@
+# install-windows.ps1 — Windows equivalent of install.sh (which supports macOS/Linux only).
+# Registers the native messaging host for Chrome/Edge/Brave under HKCU (no admin needed).
+#
+# Usage (PowerShell):
+#   .\install-windows.ps1 <extension-id> [<extension-id> ...]
+#
+# Get the extension id from chrome://extensions after loading the `extension/`
+# folder unpacked (Developer mode → Load unpacked). Restart the browser fully
+# afterwards so it re-reads native messaging manifests.
+
+param(
+  [Parameter(Mandatory = $true, ValueFromRemainingArguments = $true)]
+  [string[]]$ExtensionIds
+)
+
+$ErrorActionPreference = 'Stop'
+$HostName = 'com.anthropic.open_claude_in_chrome'
+$RepoRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+$HostDir = Join-Path $RepoRoot 'host'
+
+$node = (Get-Command node -ErrorAction SilentlyContinue).Source
+if (-not $node) { throw 'node not found on PATH. Install Node.js v18+ first.' }
+
+if (-not (Test-Path (Join-Path $HostDir 'node_modules'))) {
+  Write-Host "Installing host dependencies (npm install in $HostDir)..."
+  Push-Location $HostDir
+  npm install
+  Pop-Location
+}
+
+# Wrapper .bat — the manifest's "path" must be a Windows-executable file.
+$wrapper = Join-Path $HostDir 'native-host-wrapper.bat'
+@"
+@echo off
+"$node" "$(Join-Path $HostDir 'native-host.js')" %*
+"@ | Set-Content -Path $wrapper -Encoding ASCII
+Write-Host "Wrote $wrapper"
+
+# Native messaging host manifest.
+$manifestPath = Join-Path $HostDir "$HostName.json"
+$manifest = [ordered]@{
+  name            = $HostName
+  description     = 'Open Claude in Chrome native messaging host'
+  path            = $wrapper
+  type            = 'stdio'
+  allowed_origins = @($ExtensionIds | ForEach-Object { "chrome-extension://$_/" })
+}
+$manifest | ConvertTo-Json | Set-Content -Path $manifestPath -Encoding UTF8
+Write-Host "Wrote $manifestPath (allowed origins: $($ExtensionIds -join ', '))"
+
+# Registry keys per Chromium browser (HKCU — current user only).
+$regRoots = @(
+  'HKCU:\Software\Google\Chrome\NativeMessagingHosts',
+  'HKCU:\Software\Microsoft\Edge\NativeMessagingHosts',
+  'HKCU:\Software\BraveSoftware\Brave-Browser\NativeMessagingHosts',
+  'HKCU:\Software\Chromium\NativeMessagingHosts'
+)
+foreach ($root in $regRoots) {
+  $key = Join-Path $root $HostName
+  New-Item -Path $key -Force | Out-Null
+  Set-ItemProperty -Path $key -Name '(Default)' -Value $manifestPath
+  Write-Host "Registered $key"
+}
+
+Write-Host ''
+Write-Host 'Done. Now:'
+Write-Host '  1. Fully restart the browser (all windows) so it re-reads native messaging manifests.'
+Write-Host "  2. MCP server command for your client: node `"$(Join-Path $HostDir 'mcp-server.js')`""


### PR DESCRIPTION
install.sh only targets macOS/Linux. This adds `install-windows.ps1`, a PowerShell equivalent that:

- registers the native messaging host under HKCU (per-user, no admin) for Chrome, Edge, Brave, and Chromium
- generates the `.bat` wrapper and host manifest from the passed extension ID(s)
- installs host npm dependencies if they are missing

The README documents the Windows install path, MCP command, and manifest/registry troubleshooting. The generated wrapper and manifest are gitignored, mirroring the existing `native-host-wrapper.sh` rule.